### PR TITLE
fix: save memory

### DIFF
--- a/er-patcher
+++ b/er-patcher
@@ -23,8 +23,7 @@ if __name__ == "__main__":
 
     exe_name = Path("eldenring.exe")
     with open(exe_name, "rb") as f:
-        exe = f.read()
-    exe_hex = exe.hex()
+        exe_hex = f.read().hex()
 
     if patch.rate != 60 and patch.rate > 0:
         exe_hex = exe_hex.replace(
@@ -70,6 +69,8 @@ if __name__ == "__main__":
 
     with open(patched_exe_dir / exe_name, "wb") as f:
         f.write(bytes.fromhex(exe_hex))
+
+    del exe_hex
 
     # start patched exe directly to avoid EAC
     steam_cmd = sys.argv[1 + sys.argv.index("--"):]


### PR DESCRIPTION
Hi, thanks for making this script. I was looking at the code, and noticed that `exe` and `exe_hex` aren't being freed, so the script hogs a lot of memory while the game is running.

Before:

![memory usage before](https://user-images.githubusercontent.com/510163/157367644-cd73ffaf-0ae2-47aa-9f67-755e859814d1.png)

Fixed:

![memory usage after](https://user-images.githubusercontent.com/510163/157367649-389fdf3b-96a0-4d90-b438-5fa8b83fe64f.png)

<hr>

I used [memory-profiler](https://pypi.org/project/memory-profiler/) to do the following analysis:

Reading the exe takes up the expected 78.9MB, and the hex version is twice as big at 157.7MB.
```
    25     21.4 MiB      0.0 MiB           1       exe_name = Path("eldenring.exe")
    26    100.3 MiB      0.0 MiB           2       with open(exe_name, "rb") as f:
    27    100.3 MiB     78.9 MiB           1           exe = f.read()
    28    258.0 MiB    157.7 MiB           1       exe_hex = exe.hex()
```

The memory stays in use until the end of the script:
```
    81    258.1 MiB      0.0 MiB           1       os.rmdir(patched_exe_dir)
```
<hr>

I made two changes:

- Create `exe_hex` directly to avoid allocating `exe`.
```
    25     21.3 MiB      0.0 MiB           1       exe_name = Path("eldenring.exe")
    26    179.0 MiB      0.0 MiB           2       with open(exe_name, "rb") as f:
    27    179.0 MiB    157.7 MiB           1           exe_hex = f.read().hex()
```

- Free `exe_hex` once it's no longer needed.
```
    71    179.0 MiB      0.0 MiB           2       with open(patched_exe_dir / exe_name, "wb") as f:
    72    179.0 MiB      0.0 MiB           1           f.write(bytes.fromhex(exe_hex))
    73
    74     21.3 MiB   -157.7 MiB           1       del exe_hex
```
The alternative would be to put all the exe stuff inside a function, and `exe_hex` would get cleaned up when it goes out of scope.
