### PR TITLE
feature: improved launch

### DIFF
--- a/er-patcher
+++ b/er-patcher
@@ -25,6 +25,13 @@ if __name__ == "__main__":
     patch = parser.parse_args(patcher_args)
 
     exe_name = Path("eldenring.exe")
+
+    # If the script is in the same directory as eldenring.exe, assume that is the game directory.
+    # Otherwise, assume we are already in the game directory.
+    script_dir = Path(os.path.dirname(os.path.realpath(__file__)))
+    if (script_dir / exe_name).exists():
+        os.chdir(script_dir)
+
     with open(exe_name, "rb") as f:
         exe_hex = f.read().hex()
 

--- a/er-patcher
+++ b/er-patcher
@@ -10,7 +10,10 @@ import struct
 
 if __name__ == "__main__":
 
-    patcher_args = sys.argv[1:sys.argv.index("--")]
+    if "--" in sys.argv:
+        patcher_args = sys.argv[1:sys.argv.index("--")]
+    else:
+        patcher_args = sys.argv[1:]
     
     parser = argparse.ArgumentParser(description="Patch Elden Ring executable and launch it without EAC.")
     parser.add_argument("-r", "--rate", type=int, default=60, help="Modify the frame rate limit (e.g. 30, 120, 165 or whatever).")
@@ -73,7 +76,10 @@ if __name__ == "__main__":
     del exe_hex
 
     # start patched exe directly to avoid EAC
-    steam_cmd = sys.argv[1 + sys.argv.index("--"):]
+    if "--" in sys.argv:
+        steam_cmd = sys.argv[1 + sys.argv.index("--"):]
+    else:
+        steam_cmd = [exe_name]
     steam_cmd[-1] = Path(steam_cmd[-1]).parent.absolute() / patched_exe_dir / exe_name
     subprocess.run(steam_cmd)
 


### PR DESCRIPTION
Hi, two little features:

If `--` is not provided on the command line, default to `eldenring.exe`. This allows you to:

- Run the script from the command line with just `./er-patcher -uvca`.
- Rename the script to `.py` or `.pyw`, and launch it by double clicking it. It won't apply any patches, but if you could load options from an ini file, it would work. You can also make a shortcut, and add the arguments that way.

If the script is in the same directory as eldenring.exe, assume that is the game directory.
Otherwise, assume we are already in the game directory. This allows you to:

- Run the script while you're outside the game directory, as long as the script is in the game directory:
`C:\Users\Din>python "D:\SteamLibrary\steamapps\common\ELDEN RING\Game\er-patcher" -uvca`

Please let me know what you think 🙂 .