### PR TITLE
Improve Mod Compatibility

### DIFF
--- a/er-patcher
+++ b/er-patcher
@@ -107,7 +107,7 @@ if __name__ == "__main__":
         if f.name in ["eldenring.exe", "start_protected_game.exe", "er-patcher"]:
             continue 
         if not (game_dir_patched / f).is_file():
-             (game_dir_patched / f).hardlink_to(f)
+             f.link_to(game_dir_patched / f)
 
     # start patched exe directly to avoid EAC
     steam_cmd = sys.argv[1 + sys.argv.index("--"):]

--- a/er-patcher
+++ b/er-patcher
@@ -7,6 +7,7 @@ import argparse
 from pathlib import Path
 import struct
 import re
+from shutil import rmtree
 
 
 if __name__ == "__main__":
@@ -26,8 +27,8 @@ if __name__ == "__main__":
     parser.add_argument("-f", "--remove-60hz-fullscreen", action='store_true', help="Remove 60hz lock in fullscreen.")
     patch = parser.parse_args(patcher_args)
 
-    exe_name = Path("eldenring.exe")
-    with open(exe_name, "rb") as f:
+    game_dir = Path(".")
+    with open(game_dir / "eldenring.exe", "rb") as f:
         exe_hex = f.read().hex()
 
     if patch.rate != 60 and patch.rate > 0:
@@ -82,19 +83,36 @@ if __name__ == "__main__":
             "c745ef00000000"
         )
         
-    patched_exe_dir = Path("./er-patcher-tmp")
-    if not patched_exe_dir.is_dir():
-        patched_exe_dir.mkdir()
+    game_dir_patched = Path("er-patcher-tmp")
+    if not game_dir_patched.is_dir():
+        game_dir_patched.mkdir()
 
-    with open(patched_exe_dir / exe_name, "wb") as f:
+    with open(game_dir_patched / "eldenring.exe", "wb") as f:
         f.write(bytes.fromhex(exe_hex))
 
     del exe_hex
 
+    # recreate game directory tree in game_dir_patched
+    game_dirs = [d for d in game_dir.rglob("*") if d.is_dir()]
+    for d in game_dirs:
+        if d == game_dir_patched:
+            continue
+        if not (game_dir_patched / d).is_dir():
+             (game_dir_patched / d).mkdir(parents=True)
+
+    # hard link game files to game_dir_patched; symbolic links would be easier
+    # to handle but by default windows 10 doesn't allow them
+    game_files = [f for f in game_dir.rglob("*") if f.is_file()]
+    for f in game_files:
+        if f.name in ["eldenring.exe", "start_protected_game.exe", "er-patcher"]:
+            continue 
+        if not (game_dir_patched / f).is_file():
+             (game_dir_patched / f).hardlink_to(f)
+
     # start patched exe directly to avoid EAC
     steam_cmd = sys.argv[1 + sys.argv.index("--"):]
-    steam_cmd[-1] = Path(steam_cmd[-1]).parent.absolute() / patched_exe_dir / exe_name
-    subprocess.run(steam_cmd)
+    steam_cmd[-1] = Path(steam_cmd[-1]).parent.absolute() / game_dir_patched / "eldenring.exe"
+    subprocess.run(steam_cmd, cwd=steam_cmd[-1].parent.absolute())
 
-    os.remove(patched_exe_dir / exe_name)
-    os.rmdir(patched_exe_dir)
+    # cleanup
+    rmtree(game_dir_patched)


### PR DESCRIPTION
Dll based mods seem to only work when executable and mod.dll are in the same folder. This MR works around the issue by (hard) linking all game files to our temporary working dir which also contains the patched executable.