### PR TITLE
Feat: Added flag to allow execution with EAC enabled

### DIFF
--- a/er-patcher
+++ b/er-patcher
@@ -17,6 +17,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Patch Elden Ring executable and launch it without EAC.")
     
     parser.add_argument("-r", "--rate", type=int, default=60, help="Modify the frame rate limit (e.g. 30, 120, 165 or whatever).")
+    parser.add_argument("--with-eac", action='store_true', help="Run game with EAC (Use at own your risk)")
     parser.add_argument("--fix-camera", action='store_true', help="Disable camera auto-rotation.")
     parser.add_argument("--all", action='store_true', help="Enable all options except rate adjustment and gamplay changes like `--fix-camera`.")
     parser.add_argument("-u", "--ultrawide", action='store_true', help="Removes black bars when using a resolution with an aspect ratio other than 16:9.")
@@ -133,7 +134,7 @@ if __name__ == "__main__":
 
     # start patched exe directly to avoid EAC
     steam_cmd = sys.argv[1 + sys.argv.index("--"):]
-    steam_cmd[-1] = Path(steam_cmd[-1]).parent.absolute() / game_dir_patched / "eldenring.exe"
+    steam_cmd[-1] = Path(steam_cmd[-1]).parent.absolute() / game_dir_patched / ("start_protected_game.exe" if patch.with_eac else "eldenring.exe")
     subprocess.run(steam_cmd, cwd=steam_cmd[-1].parent.absolute())
 
     # cleanup

--- a/er-patcher
+++ b/er-patcher
@@ -51,9 +51,9 @@ if __name__ == "__main__":
             print("er-patcher: fix_camera pattern scan failed")
 
     if patch.ultrawide or patch.all:
-        uw_pattern = "8b 01 85 c0 74 42 44 8b 59 04".replace(" ", "")
+        uw_pattern = "74 50 .. 8b .. .. dc 03 00 00 .. 85 .. 74 .. .. 8b .. .. 0f af".replace(" ", "")
         if (res := re.search(uw_pattern, exe_hex)) is not None:
-            uw_addr = res.span()[0] + 8
+            uw_addr = res.span()[0]
             uw_patch = "eb"
             exe_hex = exe_hex[:uw_addr] + uw_patch + exe_hex[uw_addr + len(uw_patch):]
         else:

--- a/er-patcher
+++ b/er-patcher
@@ -51,9 +51,9 @@ if __name__ == "__main__":
             print("er-patcher: fix_camera pattern scan failed")
 
     if patch.ultrawide or patch.all:
-        uw_pattern = "74 50 .. 8b .. .. dc 03 00 00 .. 85 .. 74 .. .. 8b .. .. 0f af".replace(" ", "")
+        uw_pattern = "8b 01 85 c0 74 42 44 8b 59 04".replace(" ", "")
         if (res := re.search(uw_pattern, exe_hex)) is not None:
-            uw_addr = res.span()[0]
+            uw_addr = res.span()[0] + 8
             uw_patch = "eb"
             exe_hex = exe_hex[:uw_addr] + uw_patch + exe_hex[uw_addr + len(uw_patch):]
         else:


### PR DESCRIPTION
Hello!

I added a simple flag to allow the execution of the "start_protected_game.exe" (instead of the modified "eldenring.exe"), therefore enabling online play with the hex-edits.
I've done some testing and so far EAC has not complained.
This is obviously "dangerous", but I still think it is useful as the harm caused to other players by the use of the edits is virtually none.

Would love to hear your opinion.
Cheers. 