### PR TITLE
Flag to allow the game to run with EAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,17 @@ Note: There might be some distros (e.g. older Ubuntu releases) that launch pytho
 
 ## Features
 
-| Argument                                | Description                                                                  |
-| --------------------------------------- | ---------------------------------------------------------------------------- |
-| `-r RATE` or `--rate RATE`              | Set a custom framerate limit (default: 60).                                  |
-| `--fix-camera`                          | Disable camera auto-rotation.                                                |
+| Argument                                | Description                                                                     |
+| --------------------------------------- | ------------------------------------------------------------------------------- |
+| `-r RATE` or `--rate RATE`              | Set a custom framerate limit (default: 60).                                     |
+| `--with-eac`                            | Run game with EAC (Use at own your risk)                                        |
+| `--fix-camera`                          | Disable camera auto-rotation.                                                   |
 | `--all`                                 | Enable all options except `--rate` and<br>gameplay changes like `--fix-camera`. |
-| `-u` or `--ultrawide`                   | Remove black bars.                                                           |
-| `-v` or `--disable-vigniette`           | Remove the vigniette overlay .                                               |
-| `-c` or `--disable-ca`                  | Disable chromatic abberation.                                                |
+| `-u` or `--ultrawide`                   | Remove black bars.                                                              |
+| `-v` or `--disable-vigniette`           | Remove the vigniette overlay .                                                  |
+| `-c` or `--disable-ca`                  | Disable chromatic abberation.                                                   |
 | `-a` or `--increase-animation-distance` | Fix low frame rate animations at screen<br>edges or for distant entities.       |
-| `-s` or `--skip-intro`                  | Skip intro logos at game start.                                              |
+| `-s` or `--skip-intro`                  | Skip intro logos at game start.                                                 |
 | `-f` or `--remove-60hz-fullscreen`      | Remove the 60Hz limit in fullscreen<br>mode (not needed with proton).           |
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A tool aimed at enhancing the experience when playing the game on linux through 
 
 ## Warning
 
-**This tool is based on patching the game executable through hex-edits. However it is done in a safe and non-destructive way, that ensures the patched executable is never run with EAC enabled. Use at your own risk!** 
+**This tool is based on patching the game executable through hex-edits. However it is done in a safe and non-destructive way, that ensures the patched executable is never run with EAC enabled (unless explicity told to do so). Use at your own risk!**
 
 ## Dependencies
 
@@ -47,7 +47,7 @@ Note: This spawns a python console which will close by itself after the game has
 
 ## How it works
 
-When the game is launched through steam, the tool creates a patched version of `eldenring.exe` in a temporary subdirectory while leaving the original intact. The tool then modifies the steam launch command to launch the patched executable instead of `start_protected_game.exe`. This ensures that the patched exe is never run with EAC enabled. After the game is closed, the patched executable is removed.
+When the game is launched through steam, the tool creates a patched version of `eldenring.exe` in a temporary subdirectory while leaving the original intact. As long the flag `--with-eac` is not set, the tool modifies the steam launch command to launch the patched executable instead of `start_protected_game.exe`, thefore ensuring that the patched exe is never run with EAC enabled. After the game is closed, the patched executable is removed.
 
 ## Credits
 

--- a/er-patcher
+++ b/er-patcher
@@ -127,7 +127,7 @@ if __name__ == "__main__":
     # to handle but by default windows 10 doesn't allow them
     game_files = [f for f in game_dir.rglob("*") if f.is_file()]
     for f in game_files:
-        if f.name in ["eldenring.exe", "start_protected_game.exe", "er-patcher"]:
+        if f.name in ["eldenring.exe", "er-patcher"]:
             continue 
         if not (game_dir_patched / f).is_file():
              f.link_to(game_dir_patched / f)

--- a/er-patcher
+++ b/er-patcher
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Patch Elden Ring executable and launch it without EAC.")
     
     parser.add_argument("-r", "--rate", type=int, default=60, help="Modify the frame rate limit (e.g. 30, 120, 165 or whatever).")
-    parser.add_argument("--with-eac", action='store_false', help="Run game with EAC (Use at own your risk)")
+    parser.add_argument("--with-eac", action='store_true', help="Run game with EAC (Use at own your risk)")
     parser.add_argument("--fix-camera", action='store_true', help="Disable camera auto-rotation.")
     parser.add_argument("--all", action='store_true', help="Enable all options except rate adjustment and gamplay changes like `--fix-camera`.")
     parser.add_argument("-u", "--ultrawide", action='store_true', help="Removes black bars when using a resolution with an aspect ratio other than 16:9.")

--- a/er-patcher
+++ b/er-patcher
@@ -17,6 +17,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Patch Elden Ring executable and launch it without EAC.")
     
     parser.add_argument("-r", "--rate", type=int, default=60, help="Modify the frame rate limit (e.g. 30, 120, 165 or whatever).")
+    parser.add_argument("--with-eac", action='store_true', help="Run game with EAC (Use at own your risk)")
     parser.add_argument("--fix-camera", action='store_true', help="Disable camera auto-rotation.")
     parser.add_argument("--all", action='store_true', help="Enable all options except rate adjustment and gamplay changes like `--fix-camera`.")
     parser.add_argument("-u", "--ultrawide", action='store_true', help="Removes black bars when using a resolution with an aspect ratio other than 16:9.")
@@ -133,7 +134,7 @@ if __name__ == "__main__":
 
     # start patched exe directly to avoid EAC
     steam_cmd = sys.argv[1 + sys.argv.index("--"):]
-    steam_cmd[-1] = Path(steam_cmd[-1]).parent.absolute() / game_dir_patched / "eldenring.exe"
+    steam_cmd[-1] = Path(steam_cmd[-1]).parent.absolute() / game_dir_patched / ("start_protected_game.exe" if patch.with_eac else "eldenring.exe")
     subprocess.run(steam_cmd, cwd=steam_cmd[-1].parent.absolute())
 
     # cleanup

--- a/er-patcher
+++ b/er-patcher
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Patch Elden Ring executable and launch it without EAC.")
     
     parser.add_argument("-r", "--rate", type=int, default=60, help="Modify the frame rate limit (e.g. 30, 120, 165 or whatever).")
-    parser.add_argument("--with-eac", action='store_true', help="Run game with EAC (Use at own your risk)")
+    parser.add_argument("--with-eac", action='store_false', help="Run game with EAC (Use at own your risk)")
     parser.add_argument("--fix-camera", action='store_true', help="Disable camera auto-rotation.")
     parser.add_argument("--all", action='store_true', help="Enable all options except rate adjustment and gamplay changes like `--fix-camera`.")
     parser.add_argument("-u", "--ultrawide", action='store_true', help="Removes black bars when using a resolution with an aspect ratio other than 16:9.")


### PR DESCRIPTION
Hello All,

This Feature adds a flag to the script that allow the game to start with EAC enabled, by making Steam execute the "start_protected_game.exe" instead of the "eldenring.exe". 

At the time of writing, I've been playing the game **online** with all fixes active and with EAC enabled for the better part of a week. I'm yet to encounter any problems with EAC/Online Playing due to the hex edits, but good-judgment must be made by the player, as to whether use or not this feature. 

As evidence that it does in fact work, here is a screenshot of me playing the game **online** with all fixes active:
![image](https://user-images.githubusercontent.com/37230465/164371004-8c078ffc-42d8-445d-9bd3-ee7a07790413.png)

Best Regards,
João Pedro Braz