### PR TITLE
Update Ultrawide fix to version 1.04

### DIFF
--- a/er-patcher
+++ b/er-patcher
@@ -50,9 +50,9 @@ if __name__ == "__main__":
             print("er-patcher: fix_camera pattern scan failed")
 
     if patch.ultrawide or patch.all:
-        uw_pattern = "8b 01 85 c0 74 42 44 8b 59 04".replace(" ", "")
+        uw_pattern = "74 50 .. 8b .. .. dc 03 00 00 .. 85 .. 74 .. .. 8b .. .. 0f af".replace(" ", "")
         if (res := re.search(uw_pattern, exe_hex)) is not None:
-            uw_addr = res.span()[0] + 8
+            uw_addr = res.span()[0]
             uw_patch = "eb"
             exe_hex = exe_hex[:uw_addr] + uw_patch + exe_hex[uw_addr + len(uw_patch):]
         else:


### PR DESCRIPTION
Hello All,

This Feature updates the Ultrawide fix so it works with the 1.04 version of Elden Ring, released yesterday (20th of April 2022).

Evidence of the game running in a 21:9 resolution with the patch 1.04 applied:
![image](https://user-images.githubusercontent.com/37230465/164371540-24bc2f58-ba45-482b-b878-a97bf12eb12e.png)

Patch version (bottom right corner)
![image](https://user-images.githubusercontent.com/37230465/164371642-94fa6475-2e33-45a5-bad8-e6dec37cdfb7.png)

Best Regards,
João Pedro Braz