### PR TITLE
Fixes ultrawide for 1.05 with new pattern.

### DIFF
--- a/er-patcher
+++ b/er-patcher
@@ -51,7 +51,7 @@ if __name__ == "__main__":
             print("er-patcher: fix_camera pattern scan failed")
 
     if patch.ultrawide or patch.all:
-        uw_pattern = "74 50 .. 8b .. .. dc 03 00 00 .. 85 .. 74 .. .. 8b .. .. 0f af".replace(" ", "")
+        uw_pattern = "74 4f 45 8b 94 cc".replace(" ", "")
         if (res := re.search(uw_pattern, exe_hex)) is not None:
             uw_addr = res.span()[0]
             uw_patch = "eb"


### PR DESCRIPTION
Quick hack; using https://github.com/techiew/EldenRingMods/commit/6ec583094b73cad83d0a9104cdf37e5adb792715 for hex code references - though not using their pattern as in https://github.com/gurrgur/er-patcher/pull/33 which did not work on my machine. Potentially a hotfix changed the offset? 

Still suffers from issues described in 
https://github.com/gurrgur/er-patcher/pull/26#issuecomment-1105695837 - is not a robust reference and future game changes will certainly result in this needing patched again. Still, per the same comment; a temporary solution is at least better than no solution.

Tested locally on Arch Linux (using Proton); but should work on all machines. 

![image](https://user-images.githubusercontent.com/45638668/173907877-f11a062c-9993-45b7-8540-21f21c34fa83.png)
