### PR TITLE
Adapt to python 3.12 changes

### DIFF
--- a/er-patcher
+++ b/er-patcher
@@ -134,7 +134,7 @@ if __name__ == "__main__":
         if f.name in ["eldenring.exe", "er-patcher"]:
             continue
         if not (game_dir_patched / f).is_file():
-            f.link_to(game_dir_patched / f)
+            (game_dir_patched / f).hardlink_to(f)
 
     # start patched exe directly to avoid EAC
     steam_cmd = sys.argv[1 + sys.argv.index("--"):]


### PR DESCRIPTION
`link_to` has been replaced by `hardlink_to` in Python 3.8 and was finally removed in 3.12.

Fixes #55 