### PR TITLE
fix regression on python 3.9

### DIFF
--- a/er-patcher
+++ b/er-patcher
@@ -134,7 +134,10 @@ if __name__ == "__main__":
         if f.name in ["eldenring.exe", "er-patcher"]:
             continue
         if not (game_dir_patched / f).is_file():
-            (game_dir_patched / f).hardlink_to(f)
+            if sys.version_info.minor >= 10:
+                (game_dir_patched / f).hardlink_to(f)
+            else:
+                f.link_to(game_dir_patched / f)
 
     # start patched exe directly to avoid EAC
     steam_cmd = sys.argv[1 + sys.argv.index("--"):]


### PR DESCRIPTION
We replaced the deprecated function `link_to` with `hardlink_to` in  #56. This API has been introduced in python 3.10, so we have to use the old api when running on 3.9 or older.