### PR TITLE
Fix for crash on death with --disable-rune-loss + potential fix for 60Hz fullscreen lock 

### DIFF
--- a/er-patcher
+++ b/er-patcher
@@ -46,9 +46,9 @@ if __name__ == "__main__":
             print("er-patcher: rate pattern scan failed")
 
     if patch.disable_rune_loss:
-        rl_pattern = "b0 01 .. 8b .. e8 .. .. .. .. .. 8b .. .. .. 32 c0 .. 83 .. 28 c3".replace(" ", "")
+        rl_pattern = "41 .. 01 48 .. .. e8 .. .. .. .. 48 .. .. .. .. 32 c0".replace(" ", "")
         if (res := re.search(rl_pattern, exe_hex)) is not None:
-            rl_addr = res.span()[0] + 6
+            rl_addr = res.span()[0] + 12
             rl_patch = "90 90 90 90 90".replace(" ", "")  # NOP
             exe_hex = exe_hex[:rl_addr] + rl_patch + exe_hex[rl_addr + len(rl_patch):]
         else:
@@ -102,11 +102,15 @@ if __name__ == "__main__":
             print("er-patcher: skip_intro pattern scan failed")
 
     if patch.remove_60hz_fullscreen or patch.all:
-        fs_pattern = "c7 45 ef 3c 00 00 00".replace(" ", "")
+        fs_pattern = "eb .. c7 .. .. 3c 00 00 00 c7 .. .. 01 00 00 00".replace(" ", "")
         if (res := re.search(fs_pattern, exe_hex)) is not None:
-            fs_addr = res.span()[0] + 3
+            fs_addr = res.span()[0] + 10
             fs_patch = "00"
             exe_hex = exe_hex[:fs_addr] + fs_patch + exe_hex[fs_addr + len(fs_patch):]
+            
+            fs_addr_2 = res.span()[0] + 24
+            fs_patch_2 = "00"
+            exe_hex = exe_hex[:fs_addr_2] + fs_patch_2 + exe_hex[fs_addr_2 + len(fs_patch_2):]
         else:
             print("er-patcher: remove_60hz_fullscreen pattern scan failed")
 


### PR DESCRIPTION
Updated the hex pattern in patch.disable_rune_loss to fix the crash on death. Updated the patch.remove_60hz_fullscreen function and hex pattern to potentially fix the 60hz lock in full screen