### PR TITLE
Avoid deleting eldenring.exe while it is running

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A tool aimed at enhancing the experience when playing the game on linux through 
 1. Copy the file `er-patcher` to the game directory.
 2. In steam, set the game launch options to `python er-patcher ARGS -- %command%` See [Features](#features) for available options.
   - Example: `python er-patcher --all --rate 30 --disable-rune-loss -- %command%`
-  - Example using the [seamless co-op](https://www.nexusmods.com/eldenring/mods/510) mod: `python er-patcher --all --executable launch_elden_ring_seamlesscoop.exe -- %command%`
+  - Example using the [Seamless Co-op](https://www.nexusmods.com/eldenring/mods/510) mod: `python er-patcher --all --executable ersc_launcher.exe -- %command%`
   - Example using [MangoHud](https://github.com/flightlessmango/MangoHud) and wine fullscreen FSR: `python er-patcher --rate 144 -uvca -- env WINE_FULLSCREEN_FSR=1 MANGOHUD=1 MANGOHUD_CONFIG=histogram %command%`
 3. Launch the game through steam. `er-patcher` automatically launches a patched version of `eldenring.exe` with EAC disabled.
 

--- a/er-patcher
+++ b/er-patcher
@@ -8,16 +8,22 @@ import struct
 import re
 from shutil import rmtree
 import os
+import time
 
 def cleanup(game_dir_patched):
     if game_dir_patched.exists():
         eldenring_path = game_dir_patched / "eldenring.exe"
-        try:
-            if eldenring_path.exists():
+        while eldenring_path.exists():
+            try:
                 os.remove(eldenring_path)
-            rmtree(game_dir_patched)
-        except Exception as e:
-            print(f"er-patcher: could not delete {game_dir_patched}: {e}")
+                break
+            except PermissionError:
+                # eldenring.exe is still running, retry in 3 s
+                time.sleep(3)
+            except Exception as e:
+                print(f"er-patcher: could not delete {eldenring_path}: {e}")
+                break
+        rmtree(game_dir_patched)
 
 if __name__ == "__main__":
 

--- a/er-patcher
+++ b/er-patcher
@@ -7,7 +7,17 @@ from pathlib import Path
 import struct
 import re
 from shutil import rmtree
+import os
 
+def cleanup(game_dir_patched):
+    if game_dir_patched.exists():
+        eldenring_path = game_dir_patched / "eldenring.exe"
+        try:
+            if eldenring_path.exists():
+                os.remove(eldenring_path)
+            rmtree(game_dir_patched)
+        except Exception as e:
+            print(f"er-patcher: could not delete {game_dir_patched}: {e}")
 
 if __name__ == "__main__":
 
@@ -115,6 +125,10 @@ if __name__ == "__main__":
             print("er-patcher: remove_60hz_fullscreen pattern scan failed")
 
     game_dir_patched = Path("er-patcher-tmp")
+
+    # make sure a fresh directory is used
+    cleanup(game_dir_patched)
+
     if not game_dir_patched.is_dir():
         game_dir_patched.mkdir()
 
@@ -148,5 +162,5 @@ if __name__ == "__main__":
     steam_cmd[-1] = Path(steam_cmd[-1]).parent.absolute() / game_dir_patched / ("start_protected_game.exe" if patch.with_eac else patch.executable)
     subprocess.run(steam_cmd, cwd=steam_cmd[-1].parent.absolute())
 
-    # cleanup
-    rmtree(game_dir_patched)
+    # try to remove game_dir_patched
+    cleanup(game_dir_patched)


### PR DESCRIPTION
If you pass an `--executable` arg like when playing the Seamless Co-op mod Elden Ring does crash. The reason is `subprocess.run()` waits for the passed executable like `ersc_launcher.exe` to finish but it does not wait for `eldenring.exe` to finish. The Python script is unaware of `eldenring.exe` since it was executed by `ersc_launcher.exe`. Then `rmtree()` is called and deletes the patched `eldenring.exe` while it is running.
This PR solves this by checking if `eldenring.exe` can be accessed. If it is locked it won't be deleted. The behavior remains unchanged if `--executable` is not passed.
I tested this on Windows 11. Would be great if someone can test it on Linux aswell.

Fixes #54 
Fixes #60
Fixes #61 
