### PR TITLE
Adds disable camera reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ A tool aimed at enhancing the experience when playing the game on linux through 
   - Example for enabling HDR using gamescope on Linux (reported to work on Plasma 6.1):
 
     `ENABLE_GAMESCOPE_WSI=1 DXVK_HDR=1 gamescope -W 3440 -H 1440 -f -r 165 --hdr-enabled -- python er-patcher --all --rate 165 -- %command%`
-    
+
 3. Launch the game through steam. `er-patcher` automatically launches a patched version of `eldenring.exe` with EAC disabled.
 
-Note: There might be some distros (e.g. older Ubuntu releases) that launch python 2 instead of 3 when running `python`. In that case you'll need to replace `python` with `python3` in the launch option line. 
+Note: There might be some distros (e.g. older Ubuntu releases) that launch python 2 instead of 3 when running `python`. In that case you'll need to replace `python` with `python3` in the launch option line.
 
 ## Features
 
@@ -50,6 +50,7 @@ Note: There might be some distros (e.g. older Ubuntu releases) that launch pytho
 | `-a` or `--increase-animation-distance` | Fix low frame rate animations at screen<br>edges or for distant entities.                                 |
 | `-s` or `--skip-intro`                  | Skip intro logos at game start.                                                                           |
 | `-f` or `--remove-60hz-fullscreen`      | Remove the 60Hz limit in fullscreen<br>mode (not needed with proton).                                     |
+| `--disable-camera-reset`                | Disable camera reset on target lock input when no target in frame.                                        |
 
 
 ## Windows Support
@@ -77,3 +78,4 @@ When the game is launched through steam, the tool creates a patched version of `
 - [DarkSouls3RemoveIntroScreens](https://github.com/bladecoding/DarkSouls3RemoveIntroScreens): intro logo skip
 - [EldenRingMods](https://github.com/techiew/EldenRingMods) + [EldenRingFpsUnlockAndMore](https://github.com/uberhalit/EldenRingFpsUnlockAndMore)
   - disable rune loss
+  - disable camera reset

--- a/er-patcher
+++ b/er-patcher
@@ -42,6 +42,7 @@ if __name__ == "__main__":
     parser.add_argument("-a", "--increase-animation-distance", action='store_true', help="Increase animation distance.")
     parser.add_argument("-s", "--skip-intro", action='store_true', help="Skip intro logos.")
     parser.add_argument("-f", "--remove-60hz-fullscreen", action='store_true', help="Remove 60hz lock in fullscreen.")
+    parser.add_argument("--disable-camera-reset", action='store_true', help="Disable camera reset.")
     patch = parser.parse_args(patcher_args)
 
     if patch.with_eac and patch.executable != "eldenring.exe":
@@ -123,12 +124,21 @@ if __name__ == "__main__":
             fs_addr = res.span()[0] + 10
             fs_patch = "00"
             exe_hex = exe_hex[:fs_addr] + fs_patch + exe_hex[fs_addr + len(fs_patch):]
-            
+
             fs_addr_2 = res.span()[0] + 24
             fs_patch_2 = "00"
             exe_hex = exe_hex[:fs_addr_2] + fs_patch_2 + exe_hex[fs_addr_2 + len(fs_patch_2):]
         else:
             print("er-patcher: remove_60hz_fullscreen pattern scan failed")
+
+    if patch.disable_camera_reset:
+        cr_pattern = "80 .. .. .. .. .. 00 74 .. .. 8b .. e8 .. .. .. .. eb .. 0f 28 .. .. .. .. .. .. 8d".replace(" ", "")
+        if (res := re.search(cr_pattern, exe_hex)) is not None:
+            cr_addr = res.span()[0] + 14
+            cr_patch = "eb"
+            exe_hex = exe_hex[:cr_addr] + cr_patch + exe_hex[cr_addr + len(cr_patch):]
+        else:
+            print("er-patcher: camera reset pattern scan failed")
 
     game_dir_patched = Path("er-patcher-tmp")
 


### PR DESCRIPTION
Offset taken from https://github.com/techiew/EldenRingMods/tree/master/CameraFix

I didn't include the disable camera rotate one, because I don't use it, but I would be happy to. Also, I didn't include a short param because `-c` and `-r` were already taken.
